### PR TITLE
ECA 2491 - Support for all iOS photo orientations

### DIFF
--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -105,13 +105,13 @@
         // Handling mirrored orientations
         case UIImageOrientationUpMirrored:
             NSLog(@"Orientation: UIImageOrientationUpMirrored (2)");
-            rotation_radians = 0.0; // No rotation, but flip horizontally
+            rotation_radians = M_PI; // 180 degrees, then flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationDownMirrored:
             NSLog(@"Orientation: UIImageOrientationDownMirrored (4)");
-            rotation_radians = M_PI; // 180 degrees, then flip horizontally
+            rotation_radians = 0.0; // No rotation, but flip horizontally
             flipHorizontal = true;
             break;
             

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -81,47 +81,56 @@
     
     switch (imageOrientation) {
         case UIImageOrientationUp:
+            NSLog(@"Orientation: UIImageOrientationUp (0)");
             rotation_radians = 0.0;
             break;
             
         case UIImageOrientationDown:
+            NSLog(@"Orientation: UIImageOrientationDown (1)");
             rotation_radians = M_PI; // 180 degrees
             break;
             
         case UIImageOrientationRight:
+            NSLog(@"Orientation: UIImageOrientationRight (3)");
             rotation_radians = M_PI_2; // 90 degrees clockwise
             perpendicular = true;
             break;
             
         case UIImageOrientationLeft:
+            NSLog(@"Orientation: UIImageOrientationLeft (2)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise
             perpendicular = true;
             break;
         
         // Handling mirrored orientations
         case UIImageOrientationUpMirrored:
+            NSLog(@"Orientation: UIImageOrientationUpMirrored (4)");
             rotation_radians = 0.0; // No rotation, but flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationDownMirrored:
+            NSLog(@"Orientation: UIImageOrientationDownMirrored (5)");
             rotation_radians = M_PI; // 180 degrees, then flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationRightMirrored:
+            NSLog(@"Orientation: UIImageOrientationRightMirrored (7)");
             rotation_radians = M_PI_2; // 90 degrees clockwise, flip horizontally
             perpendicular = true;
             flipHorizontal = true;
             break;
             
         case UIImageOrientationLeftMirrored:
+            NSLog(@"Orientation: UIImageOrientationLeftMirrored (6)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise, flip horizontally
             perpendicular = true;
             flipHorizontal = true;
             break;
             
         default:
+            NSLog(@"Orientation: Unknown");
             break;
     }
     

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -74,28 +74,51 @@
     return newImage;
 }
 
-- (UIImage*)imageCorrectedForCaptureOrientation:(UIImageOrientation)imageOrientation
-{
+- (UIImage*)imageCorrectedForCaptureOrientation:(UIImageOrientation)imageOrientation {
     float rotation_radians = 0;
     bool perpendicular = false;
+    bool flipHorizontal = false;
     
     switch (imageOrientation) {
-        case UIImageOrientationUp :
+        case UIImageOrientationUp:
             rotation_radians = 0.0;
             break;
             
         case UIImageOrientationDown:
-            rotation_radians = M_PI; // don't be scared of radians, if you're reading this, you're good at math
+            rotation_radians = M_PI; // 180 degrees
             break;
             
         case UIImageOrientationRight:
-            rotation_radians = M_PI_2;
+            rotation_radians = M_PI_2; // 90 degrees clockwise
             perpendicular = true;
             break;
             
         case UIImageOrientationLeft:
-            rotation_radians = -M_PI_2;
+            rotation_radians = -M_PI_2; // 90 degrees counterclockwise
             perpendicular = true;
+            break;
+        
+        // Handling mirrored orientations
+        case UIImageOrientationUpMirrored:
+            rotation_radians = 0.0; // No rotation, but flip horizontally
+            flipHorizontal = true;
+            break;
+            
+        case UIImageOrientationDownMirrored:
+            rotation_radians = M_PI; // 180 degrees, then flip horizontally
+            flipHorizontal = true;
+            break;
+            
+        case UIImageOrientationRightMirrored:
+            rotation_radians = M_PI_2; // 90 degrees clockwise, flip horizontally
+            perpendicular = true;
+            flipHorizontal = true;
+            break;
+            
+        case UIImageOrientationLeftMirrored:
+            rotation_radians = -M_PI_2; // 90 degrees counterclockwise, flip horizontally
+            perpendicular = true;
+            flipHorizontal = true;
             break;
             
         default:
@@ -109,20 +132,71 @@
     CGContextTranslateCTM(context, self.size.width / 2, self.size.height / 2);
     CGContextRotateCTM(context, rotation_radians);
     
-    CGContextScaleCTM(context, 1.0, -1.0);
+    // Flip the image horizontally if needed
+    if (flipHorizontal) {
+        CGContextScaleCTM(context, -1.0, 1.0);
+    } else {
+        CGContextScaleCTM(context, 1.0, -1.0);
+    }
+    
     float width = perpendicular ? self.size.height : self.size.width;
     float height = perpendicular ? self.size.width : self.size.height;
     CGContextDrawImage(context, CGRectMake(-width / 2, -height / 2, width, height), [self CGImage]);
-    
-    // Move the origin back since the rotation might've change it (if its 90 degrees)
-    if (perpendicular) {
-        CGContextTranslateCTM(context, -self.size.height / 2, -self.size.width / 2);
-    }
     
     UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return newImage;
 }
+
+// - (UIImage*)imageCorrectedForCaptureOrientation:(UIImageOrientation)imageOrientation
+// {
+//     float rotation_radians = 0;
+//     bool perpendicular = false;
+    
+//     switch (imageOrientation) {
+//         case UIImageOrientationUp :
+//             rotation_radians = 0.0;
+//             break;
+            
+//         case UIImageOrientationDown:
+//             rotation_radians = M_PI; // don't be scared of radians, if you're reading this, you're good at math
+//             break;
+            
+//         case UIImageOrientationRight:
+//             rotation_radians = M_PI_2;
+//             perpendicular = true;
+//             break;
+            
+//         case UIImageOrientationLeft:
+//             rotation_radians = -M_PI_2;
+//             perpendicular = true;
+//             break;
+            
+//         default:
+//             break;
+//     }
+    
+//     UIGraphicsBeginImageContext(CGSizeMake(self.size.width, self.size.height));
+//     CGContextRef context = UIGraphicsGetCurrentContext();
+    
+//     // Rotate around the center point
+//     CGContextTranslateCTM(context, self.size.width / 2, self.size.height / 2);
+//     CGContextRotateCTM(context, rotation_radians);
+    
+//     CGContextScaleCTM(context, 1.0, -1.0);
+//     float width = perpendicular ? self.size.height : self.size.width;
+//     float height = perpendicular ? self.size.width : self.size.height;
+//     CGContextDrawImage(context, CGRectMake(-width / 2, -height / 2, width, height), [self CGImage]);
+    
+//     // Move the origin back since the rotation might've change it (if its 90 degrees)
+//     if (perpendicular) {
+//         CGContextTranslateCTM(context, -self.size.height / 2, -self.size.width / 2);
+//     }
+    
+//     UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
+//     UIGraphicsEndImageContext();
+//     return newImage;
+// }
 
 - (UIImage*)imageCorrectedForCaptureOrientation
 {

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -81,36 +81,36 @@
     
     switch (imageOrientation) {
         case UIImageOrientationUp:
-            NSLog(@"Orientation: UIImageOrientationUp (0)");
+            NSLog(@"Orientation: UIImageOrientationUp (1)");
             rotation_radians = 0.0;
             break;
             
         case UIImageOrientationDown:
-            NSLog(@"Orientation: UIImageOrientationDown (1)");
+            NSLog(@"Orientation: UIImageOrientationDown (3)");
             rotation_radians = M_PI; // 180 degrees
             break;
             
         case UIImageOrientationRight:
-            NSLog(@"Orientation: UIImageOrientationRight (3)");
+            NSLog(@"Orientation: UIImageOrientationRight (8)");
             rotation_radians = M_PI_2; // 90 degrees clockwise
             perpendicular = true;
             break;
             
         case UIImageOrientationLeft:
-            NSLog(@"Orientation: UIImageOrientationLeft (2)");
+            NSLog(@"Orientation: UIImageOrientationLeft (6)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise
             perpendicular = true;
             break;
         
         // Handling mirrored orientations
         case UIImageOrientationUpMirrored:
-            NSLog(@"Orientation: UIImageOrientationUpMirrored (4)");
+            NSLog(@"Orientation: UIImageOrientationUpMirrored (2)");
             rotation_radians = 0.0; // No rotation, but flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationDownMirrored:
-            NSLog(@"Orientation: UIImageOrientationDownMirrored (5)");
+            NSLog(@"Orientation: UIImageOrientationDownMirrored (4)");
             rotation_radians = M_PI; // 180 degrees, then flip horizontally
             flipHorizontal = true;
             break;
@@ -123,7 +123,7 @@
             break;
             
         case UIImageOrientationLeftMirrored:
-            NSLog(@"Orientation: UIImageOrientationLeftMirrored (6)");
+            NSLog(@"Orientation: UIImageOrientationLeftMirrored (5)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise, flip horizontally
             perpendicular = true;
             flipHorizontal = true;

--- a/src/ios/UIImage+CropScaleOrientation.m
+++ b/src/ios/UIImage+CropScaleOrientation.m
@@ -81,49 +81,49 @@
     
     switch (imageOrientation) {
         case UIImageOrientationUp:
-            NSLog(@"Orientation: UIImageOrientationUp (1)");
+            // NSLog(@"Orientation: UIImageOrientationUp (1)");
             rotation_radians = 0.0;
             break;
             
         case UIImageOrientationDown:
-            NSLog(@"Orientation: UIImageOrientationDown (3)");
+            // NSLog(@"Orientation: UIImageOrientationDown (3)");
             rotation_radians = M_PI; // 180 degrees
             break;
             
         case UIImageOrientationRight:
-            NSLog(@"Orientation: UIImageOrientationRight (8)");
+            // NSLog(@"Orientation: UIImageOrientationRight (8)");
             rotation_radians = M_PI_2; // 90 degrees clockwise
             perpendicular = true;
             break;
             
         case UIImageOrientationLeft:
-            NSLog(@"Orientation: UIImageOrientationLeft (6)");
+            // NSLog(@"Orientation: UIImageOrientationLeft (6)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise
             perpendicular = true;
             break;
         
         // Handling mirrored orientations
         case UIImageOrientationUpMirrored:
-            NSLog(@"Orientation: UIImageOrientationUpMirrored (2)");
+            // NSLog(@"Orientation: UIImageOrientationUpMirrored (2)");
             rotation_radians = M_PI; // 180 degrees, then flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationDownMirrored:
-            NSLog(@"Orientation: UIImageOrientationDownMirrored (4)");
+            // NSLog(@"Orientation: UIImageOrientationDownMirrored (4)");
             rotation_radians = 0.0; // No rotation, but flip horizontally
             flipHorizontal = true;
             break;
             
         case UIImageOrientationRightMirrored:
-            NSLog(@"Orientation: UIImageOrientationRightMirrored (7)");
+            // NSLog(@"Orientation: UIImageOrientationRightMirrored (7)");
             rotation_radians = M_PI_2; // 90 degrees clockwise, flip horizontally
             perpendicular = true;
             flipHorizontal = true;
             break;
             
         case UIImageOrientationLeftMirrored:
-            NSLog(@"Orientation: UIImageOrientationLeftMirrored (5)");
+            // NSLog(@"Orientation: UIImageOrientationLeftMirrored (5)");
             rotation_radians = -M_PI_2; // 90 degrees counterclockwise, flip horizontally
             perpendicular = true;
             flipHorizontal = true;


### PR DESCRIPTION
Changes to support all 8 values in the UIImageOrientation enum.
These orientations are now rotated and flipped as necessary:

UIImageOrientationUpMirrored (2) - rotated 180 and flipped
UIImageOrientationDownMirrored (4) - NO rotation but flipped
UIImageOrientationRightMirrored (7) - rotated 90 clockwise and flipped
UIImageOrientationLeftMirrored (5) - rotated 90 counterclockwise and flipped